### PR TITLE
SECURESIGN-115 | Add new label to dockerfiles for Comet

### DIFF
--- a/redhat/overlays/Dockerfile
+++ b/redhat/overlays/Dockerfile
@@ -17,5 +17,6 @@ RUN chgrp -R 0 /${HOME} && chmod -R g=u /${HOME}
 
 WORKDIR ${HOME}
 
+LABEL com.redhat.component="gitsign"
 # Makes sure the container stays running
 CMD ["tail", "-f", "/dev/null"]


### PR DESCRIPTION
This pr is related to this issue https://issues.redhat.com/browse/SECURESIGN-115, and involves adding an extra label to the Dockerfile for Comet.