### PR TITLE
feat: Add GH action

### DIFF
--- a/.github/workflows/cronjobs.yaml
+++ b/.github/workflows/cronjobs.yaml
@@ -1,0 +1,17 @@
+name: GH Actions Cron Schedule
+on:
+  workflow_dispatch:
+  schedule:
+    # Every M-F at 12:00am run this job
+    - cron:  "0 0 * * 1-5"
+    
+jobs:
+  check-image-version:
+    uses: securesign/actions/.github/workflows/check-image-version.yaml@main
+    strategy:
+      matrix:
+        branch: [main, midstream-v0.7.1]
+    with:
+      branch: ${{ matrix.branch }}
+    secrets:
+      token: ${{ secrets.GITHUB_TOKEN }}


### PR DESCRIPTION
Pr to add the check-image-version action to the scaffolding repo. Example prs : https://github.com/JasonPowr/gitsign/pull/3, https://github.com/JasonPowr/gitsign/pull/2

## Important
Before merged settings need to be changed.

1. Actions need to be able to create pull requests (settings -> Actions -> General -> Workflow permissions)
2. Actions need read and write permissions (settings -> Actions -> General -> Workflow permissions)