### PR TITLE
[SECURESIGN-361] update cronjob to use prod branch

### DIFF
--- a/.github/workflows/cronjobs.yaml
+++ b/.github/workflows/cronjobs.yaml
@@ -4,13 +4,13 @@ on:
   schedule:
     # Every M-F at 12:00am run this job
     - cron:  "0 0 * * 1-5"
-    
+
 jobs:
   check-image-version:
     uses: securesign/actions/.github/workflows/check-image-version.yaml@main
     strategy:
       matrix:
-        branch: [main, midstream-v0.7.1]
+        branch: [main, redhat-v0.8]
     with:
       branch: ${{ matrix.branch }}
     secrets:


### PR DESCRIPTION
Updates to the `redhat-v0.8` branch.