### PR TITLE
fix: don't print stack to stdout

### DIFF
--- a/internal/io/streams.go
+++ b/internal/io/streams.go
@@ -19,7 +19,6 @@ import (
 	"fmt"
 	"io"
 	"os"
-	"runtime/debug"
 
 	"github.com/mattn/go-tty"
 )
@@ -72,7 +71,7 @@ func (s *Streams) Wrap(fn func() error) error {
 	// Log any panics to ttyout, since otherwise they will be lost to os.Stderr.
 	defer func() {
 		if r := recover(); r != nil {
-			fmt.Fprintln(s.TTYOut, r, string(debug.Stack()))
+			fmt.Fprintln(s.TTYOut, r)
 		}
 	}()
 


### PR DESCRIPTION
Printing the stack trace could potentially reveal sensitive information from within the process. This is documented in CWE-209 (https://cwe.mitre.org/data/definitions/209.html) and is considered a High Severity weakness by prodsec. This commit removes that.