### PR TITLE
rm-nudging-annotation

### DIFF
--- a/.tekton/gitsign-push.yaml
+++ b/.tekton/gitsign-push.yaml
@@ -8,7 +8,6 @@ metadata:
     pipelinesascode.tekton.dev/max-keep-runs: "3"
     pipelinesascode.tekton.dev/on-cel-expression: event == "push" && target_branch
       == "main"
-    build.appstudio.openshift.io/build-nudge-files: "controllers/constants/*"
   creationTimestamp: null
   labels:
     appstudio.openshift.io/application: cli


### PR DESCRIPTION
This is un needed and stopping gitsign from nudging client-server-cg