### PR TITLE
feat(fips): bumping Go to 1.24

### DIFF
--- a/.tekton/gitsign-pull-request.yaml
+++ b/.tekton/gitsign-pull-request.yaml
@@ -40,8 +40,6 @@ spec:
     value: "true"
   - name: go_test_command
     value: go test $(go list ./... | grep -v github.com/sigstore/gitsign/pkg/version)
-  - name: go_base_image
-    value: brew.registry.redhat.io/rh-osbs/openshift-golang-builder:rhel_9_1.23@sha256:44fd8f88f3b6463cda15571260f9ca3a0b78d3c8c8827a338e04ab3a23581a88
   pipelineRef:
     params:
     - name: url

--- a/.tekton/gitsign-push.yaml
+++ b/.tekton/gitsign-push.yaml
@@ -37,8 +37,6 @@ spec:
     value: "true"
   - name: go_test_command
     value: go test $(go list ./... | grep -v github.com/sigstore/gitsign/pkg/version)
-  - name: go_base_image
-    value: brew.registry.redhat.io/rh-osbs/openshift-golang-builder:rhel_9_1.23@sha256:44fd8f88f3b6463cda15571260f9ca3a0b78d3c8c8827a338e04ab3a23581a88
   pipelineRef:
     params:
     - name: url

--- a/Dockerfile.gitsign.rh
+++ b/Dockerfile.gitsign.rh
@@ -1,5 +1,9 @@
 # Build stage
-FROM brew.registry.redhat.io/rh-osbs/openshift-golang-builder:rhel_9_1.23@sha256:44fd8f88f3b6463cda15571260f9ca3a0b78d3c8c8827a338e04ab3a23581a88 AS build-env
+FROM registry.redhat.io/ubi9/go-toolset:1.24@sha256:6fd64cd7f38a9b87440f963b6c04953d04de65c35b9672dbd7f1805b0ae20d09 AS build-env
+
+ENV GOEXPERIMENT=strictfipsruntime
+ENV CGO_ENABLED=1
+
 WORKDIR /gitsign
 RUN git config --global --add safe.directory /gitsign
 COPY . .


### PR DESCRIPTION
## Summary by Sourcery

Bump Go to version 1.24 across the project and remove obsolete base image references from pipelines

Enhancements:
- Remove go_base_image environment variable from Tekton gitsign-pull-request and gitsign-push configurations
- Update Dockerfile.gitsign.rh to use the Go 1.24 base image