### PR TITLE
chore(KONFLUX-6210): fix and set name and cpe label for gitsign

### DIFF
--- a/Dockerfile.gitsign.rh
+++ b/Dockerfile.gitsign.rh
@@ -33,7 +33,8 @@ LABEL io.k8s.display-name="Gitsign container image for Red Hat Trusted Artifact 
 LABEL io.openshift.tags="gitsign trusted-artifact-signer"
 LABEL summary="Provides the gitsign CLI binary for signing and verifying container images."
 LABEL com.redhat.component="gitsign"
-LABEL name="gitsign"
+LABEL name="rhtas/gitsign-rhel9"
+LABEL cpe="cpe:/a:redhat:trusted_artifact_signer:1.2::el9"
 
 COPY --from=build-env /gitsign/gitsign_cli_darwin_amd64.gz /usr/local/bin/gitsign_cli_darwin_amd64.gz
 COPY --from=build-env /gitsign/gitsign_cli_linux_amd64.gz /usr/local/bin/gitsign_cli_linux_amd64.gz


### PR DESCRIPTION
For https://issues.redhat.com/browse/KONFLUX-6210, clair needs access to a name and cpe label that it can use to look up the image in VEX statements.

See also release-engineering/rhtap-ec-policy#149

Signed-off-by: Ralph Bean <rbean@redhat.com>
Assisted-by: Gemini

## Summary by Sourcery

Bug Fixes:
- Add NAME and CPE_LABEL Docker labels to the gitsign image