### PR TITLE
Removing CPE label

### DIFF
--- a/Dockerfile.gitsign.rh
+++ b/Dockerfile.gitsign.rh
@@ -34,7 +34,6 @@ LABEL io.openshift.tags="gitsign trusted-artifact-signer"
 LABEL summary="Provides the gitsign CLI binary for signing and verifying container images."
 LABEL com.redhat.component="gitsign"
 LABEL name="rhtas/gitsign-rhel9"
-LABEL cpe="cpe:/a:redhat:trusted_artifact_signer:1.2::el9"
 
 COPY --from=build-env /gitsign/gitsign_cli_darwin_amd64.gz /usr/local/bin/gitsign_cli_darwin_amd64.gz
 COPY --from=build-env /gitsign/gitsign_cli_linux_amd64.gz /usr/local/bin/gitsign_cli_linux_amd64.gz


### PR DESCRIPTION
## Summary by Sourcery

Chores:
- Remove CPE label from Dockerfile.gitsign.rh