### PR TITLE
Update release-version to 1.3.5

### DIFF
--- a/.tekton/gitsign-pull-request.yaml
+++ b/.tekton/gitsign-pull-request.yaml
@@ -19,7 +19,7 @@ metadata:
 spec:
   params:
   - name: release-version
-    value: 1.3.4
+    value: 1.3.5
   - name: dockerfile
     value: Dockerfile.gitsign.rh
   - name: git-url

--- a/.tekton/gitsign-push.yaml
+++ b/.tekton/gitsign-push.yaml
@@ -18,7 +18,7 @@ metadata:
 spec:
   params:
   - name: release-version
-    value: 1.3.4
+    value: 1.3.5
   - name: dockerfile
     value: Dockerfile.gitsign.rh
   - name: git-url


### PR DESCRIPTION
## Summary
- Update release-version parameter to 1.3.5 in Tekton pipeline files

## Test plan
- Verify Tekton pipelines run with version 1.3.5

🤖 Generated with [Claude Code](https://claude.com/claude-code)