### PR TITLE
Update release-version to 1.4.1

### DIFF
--- a/.tekton/gitsign-pull-request.yaml
+++ b/.tekton/gitsign-pull-request.yaml
@@ -18,7 +18,7 @@ metadata:
 spec:
   params:
   - name: release-version
-    value: 1.4.0
+    value: 1.4.1
   - name: dockerfile
     value: Dockerfile.gitsign.rh
   - name: git-url

--- a/.tekton/gitsign-push.yaml
+++ b/.tekton/gitsign-push.yaml
@@ -18,7 +18,7 @@ metadata:
 spec:
   params:
   - name: release-version
-    value: 1.4.0
+    value: 1.4.1
   - name: dockerfile
     value: Dockerfile.gitsign.rh
   - name: git-url


### PR DESCRIPTION
## Summary
- Update release-version parameter from 1.4.0 to 1.4.1 in Tekton pipeline files

## Test plan
- Verify Tekton pipelines run with version 1.4.1

🤖 Generated with [Claude Code](https://claude.com/claude-code)