### PR TITLE
build: rework cli-stack, move cross-compilation out of component image

### DIFF
--- a/.tekton/gitsign-cli-stack-v1-4-pull-request.yaml
+++ b/.tekton/gitsign-cli-stack-v1-4-pull-request.yaml
@@ -32,7 +32,7 @@ spec:
   - name: revision
     value: '{{revision}}'
   - name: hermetic
-    value: "true"
+    value: "false"
   - name: build-source-image
     value: "true"
   pipelineRef:

--- a/.tekton/gitsign-cli-stack-v1-4-pull-request.yaml
+++ b/.tekton/gitsign-cli-stack-v1-4-pull-request.yaml
@@ -31,10 +31,8 @@ spec:
     value: .
   - name: revision
     value: '{{revision}}'
-  - name: prefetch-input
-    value: '{"type": "gomod", "path": "."}'
   - name: hermetic
-    value: "true"
+    value: "false"
   - name: build-source-image
     value: "true"
   pipelineRef:

--- a/.tekton/gitsign-cli-stack-v1-4-pull-request.yaml
+++ b/.tekton/gitsign-cli-stack-v1-4-pull-request.yaml
@@ -31,8 +31,10 @@ spec:
     value: .
   - name: revision
     value: '{{revision}}'
+  - name: prefetch-input
+    value: '{"type": "gomod", "path": "."}'
   - name: hermetic
-    value: "false"
+    value: "true"
   - name: build-source-image
     value: "true"
   pipelineRef:

--- a/.tekton/gitsign-cli-stack-v1-4-push.yaml
+++ b/.tekton/gitsign-cli-stack-v1-4-push.yaml
@@ -32,7 +32,7 @@ spec:
   - name: prefetch-input
     value: '{"type": "gomod", "path": "."}'
   - name: hermetic
-    value: "false"
+    value: "true"
   - name: build-source-image
     value: "true"
   pipelineRef:

--- a/.tekton/gitsign-cli-stack-v1-4-push.yaml
+++ b/.tekton/gitsign-cli-stack-v1-4-push.yaml
@@ -32,7 +32,7 @@ spec:
   - name: prefetch-input
     value: '{"type": "gomod", "path": "."}'
   - name: hermetic
-    value: "true"
+    value: "false"
   - name: build-source-image
     value: "true"
   pipelineRef:

--- a/.tekton/gitsign-cli-stack-v1-4-push.yaml
+++ b/.tekton/gitsign-cli-stack-v1-4-push.yaml
@@ -29,8 +29,10 @@ spec:
     value: .
   - name: revision
     value: '{{revision}}'
+  - name: prefetch-input
+    value: '{"type": "gomod", "path": "."}'
   - name: hermetic
-    value: "true"
+    value: "false"
   - name: build-source-image
     value: "true"
   pipelineRef:

--- a/Build.mak
+++ b/Build.mak
@@ -17,7 +17,11 @@ endif
 LDFLAGS=-buildid= -X github.com/sigstore/gitsign/pkg/version.gitVersion=$(GIT_VERSION)
 FIPS_MODULE ?= latest
 
-.PHONY: 
+.PHONY: gitsign-cli-linux
+gitsign-cli-linux: ## Build native Linux binary (FIPS, CGO)
+	env CGO_ENABLED=1 GOEXPERIMENT=strictfipsruntime go build -mod=readonly -o gitsign_cli_linux -trimpath -ldflags "$(LDFLAGS) -w -s" .
+
+.PHONY:
 cross-platform: gitsign-cli-darwin-arm64 gitsign-cli-darwin-amd64 gitsign-cli-windows ## Build all distributable (cross-platform) binaries
 
 .PHONY:	gitsign-cli-darwin-arm64

--- a/Dockerfile.cli-stack.rh
+++ b/Dockerfile.cli-stack.rh
@@ -1,53 +1,61 @@
-FROM --platform=linux/amd64   quay.io/securesign/gitsign@sha256:2e655e1da4872062d38eafbe8e6f5658ad3330103407383605c33e86b6f4adde AS build-amd64
-FROM --platform=linux/arm64   quay.io/securesign/gitsign@sha256:f15ed2c2bfd1f6ceb496fea1f37b00b84d023a66863b7dc703fa4f92e3a7c93a AS build-arm64
-FROM --platform=linux/ppc64le quay.io/securesign/gitsign@sha256:5779f5d553f19461e04b218a65b56911a73c64d084f18d964f3acb71a9ce422d AS build-ppc64le
-FROM --platform=linux/s390x   quay.io/securesign/gitsign@sha256:c1a4b60442c7ae5c01ff6e83228f4cbc4c58d26f26f86d24abef7b55e6d17796 AS build-s390x
+FROM registry.redhat.io/ubi9/go-toolset:9.7-1778604137@sha256:e06a6f4c85c3ca75f64127542449c9770fb885adfb592f987c576d268ac108de AS build-cross-platform
+ENV APP_ROOT=/opt/app-root \
+    GOPATH=/opt/app-root
+
+USER root
+WORKDIR $APP_ROOT/src
+ADD go.mod go.sum ./
+ADD ./ ./
+
+RUN git config --global --add safe.directory /opt/app-root/src && \
+    git update-index --assume-unchanged Dockerfile.gitsign.rh && \
+    git update-index --assume-unchanged Dockerfile.cli-stack.rh && \
+    go mod download && \
+    make -f Build.mak cross-platform
+
+FROM --platform=linux/amd64   quay.io/securesign/gitsign@sha256:61c04a5c2ad25d458278ebe62914f8d803610888cd2d464d3753ea8ec975dfe2 AS build-amd64
+FROM --platform=linux/arm64   quay.io/securesign/gitsign@sha256:61c04a5c2ad25d458278ebe62914f8d803610888cd2d464d3753ea8ec975dfe2 AS build-arm64
+FROM --platform=linux/ppc64le quay.io/securesign/gitsign@sha256:61c04a5c2ad25d458278ebe62914f8d803610888cd2d464d3753ea8ec975dfe2 AS build-ppc64le
+FROM --platform=linux/s390x   quay.io/securesign/gitsign@sha256:61c04a5c2ad25d458278ebe62914f8d803610888cd2d464d3753ea8ec975dfe2 AS build-s390x
 
 FROM registry.redhat.io/ubi9/go-toolset:9.7-1778604137@sha256:e06a6f4c85c3ca75f64127542449c9770fb885adfb592f987c576d268ac108de AS packager
 USER root
 RUN mkdir -p /binaries
 
-# Native Linux binaries from each arch variant
-COPY --from=build-amd64 /usr/local/bin/gitsign_cli_linux.gz /tmp/gitsign_cli_linux.gz
-RUN gzip -d /tmp/gitsign_cli_linux.gz && \
-    tar -czf /binaries/gitsign_cli_linux_amd64.tar.gz -C /tmp gitsign_cli_linux && \
+# gitsign: Native Linux binaries from each arch variant
+COPY --from=build-amd64 /usr/local/bin/gitsign_cli_linux /tmp/gitsign_cli_linux
+RUN tar -czf /binaries/gitsign_cli_linux_amd64.tar.gz -C /tmp gitsign_cli_linux && \
     rm /tmp/gitsign_cli_linux
 
-COPY --from=build-arm64 /usr/local/bin/gitsign_cli_linux.gz /tmp/gitsign_cli_linux.gz
-RUN gzip -d /tmp/gitsign_cli_linux.gz && \
-    tar -czf /binaries/gitsign_cli_linux_arm64.tar.gz -C /tmp gitsign_cli_linux && \
+COPY --from=build-arm64 /usr/local/bin/gitsign_cli_linux /tmp/gitsign_cli_linux
+RUN tar -czf /binaries/gitsign_cli_linux_arm64.tar.gz -C /tmp gitsign_cli_linux && \
     rm /tmp/gitsign_cli_linux
 
-COPY --from=build-ppc64le /usr/local/bin/gitsign_cli_linux.gz /tmp/gitsign_cli_linux.gz
-RUN gzip -d /tmp/gitsign_cli_linux.gz && \
-    tar -czf /binaries/gitsign_cli_linux_ppc64le.tar.gz -C /tmp gitsign_cli_linux && \
+COPY --from=build-ppc64le /usr/local/bin/gitsign_cli_linux /tmp/gitsign_cli_linux
+RUN tar -czf /binaries/gitsign_cli_linux_ppc64le.tar.gz -C /tmp gitsign_cli_linux && \
     rm /tmp/gitsign_cli_linux
 
-COPY --from=build-s390x /usr/local/bin/gitsign_cli_linux.gz /tmp/gitsign_cli_linux.gz
-RUN gzip -d /tmp/gitsign_cli_linux.gz && \
-    tar -czf /binaries/gitsign_cli_linux_s390x.tar.gz -C /tmp gitsign_cli_linux && \
+COPY --from=build-s390x /usr/local/bin/gitsign_cli_linux /tmp/gitsign_cli_linux
+RUN tar -czf /binaries/gitsign_cli_linux_s390x.tar.gz -C /tmp gitsign_cli_linux && \
     rm /tmp/gitsign_cli_linux
 
-# Darwin amd64
-COPY --from=build-amd64 /usr/local/bin/gitsign_cli_darwin_amd64.gz /tmp/gitsign_cli_darwin_amd64.gz
-RUN gzip -d /tmp/gitsign_cli_darwin_amd64.gz && \
-    tar -czf /binaries/gitsign_cli_darwin_amd64.tar.gz -C /tmp gitsign_cli_darwin_amd64 && \
+# gitsign: Cross-compiled binaries
+COPY --from=build-cross-platform /opt/app-root/src/gitsign_cli_darwin_amd64 /tmp/gitsign_cli_darwin_amd64
+RUN tar -czf /binaries/gitsign_cli_darwin_amd64.tar.gz -C /tmp gitsign_cli_darwin_amd64 && \
     rm /tmp/gitsign_cli_darwin_amd64
 
-# Darwin arm64
-COPY --from=build-amd64 /usr/local/bin/gitsign_cli_darwin_arm64.gz /tmp/gitsign_cli_darwin_arm64.gz
-RUN gzip -d /tmp/gitsign_cli_darwin_arm64.gz && \
-    tar -czf /binaries/gitsign_cli_darwin_arm64.tar.gz -C /tmp gitsign_cli_darwin_arm64 && \
+COPY --from=build-cross-platform /opt/app-root/src/gitsign_cli_darwin_arm64 /tmp/gitsign_cli_darwin_arm64
+RUN tar -czf /binaries/gitsign_cli_darwin_arm64.tar.gz -C /tmp gitsign_cli_darwin_arm64 && \
     rm /tmp/gitsign_cli_darwin_arm64
 
-# Windows amd64
-COPY --from=build-amd64 /usr/local/bin/gitsign_cli_windows_amd64.exe.gz /tmp/gitsign_cli_windows_amd64.exe.gz
-RUN gzip -d /tmp/gitsign_cli_windows_amd64.exe.gz && \
-    tar -czf /binaries/gitsign_cli_windows_amd64.tar.gz -C /tmp gitsign_cli_windows_amd64.exe && \
+COPY --from=build-cross-platform /opt/app-root/src/gitsign_cli_windows_amd64.exe /tmp/gitsign_cli_windows_amd64.exe
+RUN tar -czf /binaries/gitsign_cli_windows_amd64.tar.gz -C /tmp gitsign_cli_windows_amd64.exe && \
     rm /tmp/gitsign_cli_windows_amd64.exe
 
+RUN chmod -R a+rX /binaries
+
 # Final minimal image with all binaries
-FROM registry.redhat.io/ubi9/ubi-minimal@sha256:12db9874bd753eb98b1ab3d840e75de5d6842ac0604fbd68c012adefe97140be
+FROM registry.redhat.io/ubi9/ubi-micro:9.8@sha256:b498b3ea26111ab4b81d65139f2ebd2ef9a2abb7a4588b7fdcc54889f95e9caa
 
 LABEL description="Flat image containing gitsign CLI binaries for all platforms and architectures"
 LABEL io.k8s.description="Flat image containing gitsign CLI binaries for all platforms and architectures"
@@ -56,10 +64,9 @@ LABEL io.k8s.display-name="Gitsign CLI stack image for Red Hat Trusted Artifact 
 LABEL io.openshift.tags="gitsign trusted-artifact-signer cli-stack"
 LABEL summary="Provides all gitsign CLI binaries as tar.gz archives for CDN distribution."
 LABEL com.redhat.component="gitsign-cli-stack"
+LABEL name="rhtas/gitsign-cli-stack"
 
 COPY --from=packager /binaries/ /binaries/
 COPY --from=build-amd64 /licenses/ /licenses/
-
-RUN chown -R root:0 /binaries && chmod -R g+r /binaries
 
 USER 65532:65532

--- a/Dockerfile.gitsign.rh
+++ b/Dockerfile.gitsign.rh
@@ -1,29 +1,16 @@
 # Build stage
 FROM registry.redhat.io/ubi9/go-toolset:9.7-1778604137@sha256:e06a6f4c85c3ca75f64127542449c9770fb885adfb592f987c576d268ac108de AS build-env
 
-ENV GOEXPERIMENT=strictfipsruntime
-ENV CGO_ENABLED=1
-
 WORKDIR /gitsign
 RUN git config --global --add safe.directory /gitsign
 COPY . .
 USER root
 RUN git stash && \
-    export GIT_VERSION=$(git describe --tags --always --dirty) && \
-    export GIT_HASH=$(git rev-parse HEAD) && \
-    export BUILD_DATE=$(date -u +'%Y-%m-%dT%H:%M:%SZ') && \
     git stash pop || true && \
+    git update-index --assume-unchanged Dockerfile.gitsign.rh && \
     go mod download && \
-    LDFLAGS="-X sigs.k8s.io/release-utils/version.gitVersion=${GIT_VERSION} \
-                   -X sigs.k8s.io/release-utils/version.gitCommit=${GIT_HASH} \
-                   -X sigs.k8s.io/release-utils/version.gitTreeState="clean" \
-                   -X sigs.k8s.io/release-utils/version.buildDate=${BUILD_DATE}"; \
-    go build -mod=readonly -o gitsign_cli_linux -trimpath -ldflags "${LDFLAGS} -w -s" . && \
-    gzip -k gitsign_cli_linux && \
-    make -f Build.mak cross-platform && \
-    gzip gitsign_cli_darwin_amd64 && \
-    gzip gitsign_cli_windows_amd64.exe && \
-    gzip gitsign_cli_darwin_arm64
+    make -f Build.mak gitsign-cli-linux && \
+    git update-index --no-assume-unchanged Dockerfile.gitsign.rh
 
 # Install Gitsign
 FROM registry.access.redhat.com/ubi9-minimal@sha256:12db9874bd753eb98b1ab3d840e75de5d6842ac0604fbd68c012adefe97140be
@@ -37,20 +24,12 @@ LABEL com.redhat.component="gitsign"
 LABEL name="rhtas/gitsign-rhel9"
 
 COPY --from=build-env /gitsign/gitsign_cli_linux /usr/local/bin/gitsign_cli_linux
-COPY --from=build-env /gitsign/gitsign_cli_linux.gz /usr/local/bin/gitsign_cli_linux.gz
-COPY --from=build-env /gitsign/gitsign_cli_darwin_amd64.gz /usr/local/bin/gitsign_cli_darwin_amd64.gz
-COPY --from=build-env /gitsign/gitsign_cli_darwin_arm64.gz /usr/local/bin/gitsign_cli_darwin_arm64.gz
-COPY --from=build-env /gitsign/gitsign_cli_windows_amd64.exe.gz /usr/local/bin/gitsign_cli_windows_amd64.exe.gz
 COPY LICENSE /licenses/license.txt
 
 ENV HOME=/home
 WORKDIR ${HOME}
 
-RUN chown root:0 /usr/local/bin/gitsign_cli_darwin_amd64.gz && chmod g+wx /usr/local/bin/gitsign_cli_darwin_amd64.gz && \
-    chown root:0 /usr/local/bin/gitsign_cli_windows_amd64.exe.gz && chmod g+wx /usr/local/bin/gitsign_cli_windows_amd64.exe.gz && \
-    chown root:0 /usr/local/bin/gitsign_cli_darwin_arm64.gz && chmod g+wx /usr/local/bin/gitsign_cli_darwin_arm64.gz && \
-    chown root:0 /usr/local/bin/gitsign_cli_linux.gz && chmod g+wx /usr/local/bin/gitsign_cli_linux.gz && \
-    chgrp -R 0 /${HOME} && chmod -R g=u /${HOME}
+RUN chgrp -R 0 /${HOME} && chmod -R g=u /${HOME}
 
 USER 65532:65532
 


### PR DESCRIPTION
## Summary
Backport of #357 to release-1.4.

- **Component Dockerfile** (`Dockerfile.gitsign.rh`): Remove cross-compilation and gzip. Output is now a single native `gitsign_cli_linux` binary.
- **CLI-stack Dockerfile** (`Dockerfile.cli-stack.rh`): Add `build-cross-platform` stage (go-toolset, CGO_ENABLED=0). Use single manifest digest (`sha256:61c04a5c...`) for all 4 arch FROM lines. Copy native binaries directly. Switch final image to `ubi-micro:9.8`.
- **Build.mak**: Add `gitsign-cli-linux` target for native-only build.
- **Tekton pipelines**: Set `hermetic: "false"` for cli-stack, add `prefetch-input` for gomod.

Release-1.4 go-toolset digest and branch-specific Tekton names preserved.

## Test plan
- [ ] Component image build succeeds on Konflux
- [ ] CLI-stack build succeeds after component rebuild + nudge
- [ ] Enterprise Contract passes