### PR TITLE
fix: disable hermetic builds for cli-stacks v1.4

### DIFF
--- a/.tekton/gitsign-cli-stack-v1-4-pull-request.yaml
+++ b/.tekton/gitsign-cli-stack-v1-4-pull-request.yaml
@@ -32,7 +32,7 @@ spec:
   - name: revision
     value: '{{revision}}'
   - name: hermetic
-    value: "true"
+    value: "false"
   - name: build-source-image
     value: "true"
   pipelineRef:

--- a/.tekton/gitsign-cli-stack-v1-4-push.yaml
+++ b/.tekton/gitsign-cli-stack-v1-4-push.yaml
@@ -30,7 +30,7 @@ spec:
   - name: revision
     value: '{{revision}}'
   - name: hermetic
-    value: "true"
+    value: "false"
   - name: build-source-image
     value: "true"
   pipelineRef:


### PR DESCRIPTION
## Summary
- Disable hermetic builds in gitsign cli-stack Tekton pipelines for release-1.4
- Allows network access during builds for dependency resolution

## Changes
- Set `hermetic: "false"` in `.tekton/gitsign-cli-stack-v1-4-pull-request.yaml`
- Set `hermetic: "false"` in `.tekton/gitsign-cli-stack-v1-4-push.yaml`

## Reason
Hermetic builds were preventing the cli-stack pipelines from accessing network resources needed for dependency resolution. This aligns with the configuration used in other cli-stacks components (rekor, trillian, tough, timestamp-authority).

## Test plan
- [ ] Verify PR pipeline triggers and builds successfully
- [ ] Verify push pipeline builds after merge
- [ ] Confirm cli-stack image is published to quay.io/securesign/gitsign-cli-stack

🤖 Generated with [Claude Code](https://claude.com/claude-code)