### PR TITLE
Add ALLOW_CROSS_PLATFORM_IMAGES parameter to cli-stack pipelines

### DIFF
--- a/.tekton/gitsign-cli-stack-v1-4-pull-request.yaml
+++ b/.tekton/gitsign-cli-stack-v1-4-pull-request.yaml
@@ -35,6 +35,8 @@ spec:
     value: "false"
   - name: build-source-image
     value: "true"
+  - name: ALLOW_CROSS_PLATFORM_IMAGES
+    value: "true"
   pipelineRef:
     params:
     - name: url

--- a/.tekton/gitsign-cli-stack-v1-4-push.yaml
+++ b/.tekton/gitsign-cli-stack-v1-4-push.yaml
@@ -35,6 +35,8 @@ spec:
     value: "false"
   - name: build-source-image
     value: "true"
+  - name: ALLOW_CROSS_PLATFORM_IMAGES
+    value: "true"
   pipelineRef:
     params:
     - name: url


### PR DESCRIPTION
## Summary
- Add `ALLOW_CROSS_PLATFORM_IMAGES` parameter to gitsign cli-stack build pipelines
- Enables multi-platform image support in Konflux builds

## Context
This change aligns with similar updates made across the securesign repositories to support multi-platform container images in cli-stack builds.

## Test plan
- [ ] Verify pipeline runs successfully with the new parameter
- [ ] Confirm multi-platform images are built correctly

🤖 Generated with [Claude Code](https://claude.com/claude-code)