### PR TITLE
Update cli-stack with platform-specific digests

### DIFF
--- a/.tekton/gitsign-cli-stack-v1-4-pull-request.yaml
+++ b/.tekton/gitsign-cli-stack-v1-4-pull-request.yaml
@@ -35,6 +35,8 @@ spec:
     value: "false"
   - name: build-source-image
     value: "true"
+  - name: ALLOW_CROSS_PLATFORM_IMAGES
+    value: "true"
   pipelineRef:
     params:
     - name: url

--- a/.tekton/gitsign-cli-stack-v1-4-push.yaml
+++ b/.tekton/gitsign-cli-stack-v1-4-push.yaml
@@ -35,6 +35,8 @@ spec:
     value: "false"
   - name: build-source-image
     value: "true"
+  - name: ALLOW_CROSS_PLATFORM_IMAGES
+    value: "true"
   pipelineRef:
     params:
     - name: url

--- a/Dockerfile.cli-stack.rh
+++ b/Dockerfile.cli-stack.rh
@@ -13,10 +13,10 @@ RUN git config --global --add safe.directory /opt/app-root/src && \
     go mod download && \
     make -f Build.mak cross-platform
 
-FROM --platform=linux/amd64   quay.io/securesign/gitsign@sha256:482cd580642d2ba2da727dec81c486e580e1e4c895749b59a3e96d30a47e79a8 AS build-amd64
-FROM --platform=linux/arm64   quay.io/securesign/gitsign@sha256:482cd580642d2ba2da727dec81c486e580e1e4c895749b59a3e96d30a47e79a8 AS build-arm64
-FROM --platform=linux/ppc64le quay.io/securesign/gitsign@sha256:482cd580642d2ba2da727dec81c486e580e1e4c895749b59a3e96d30a47e79a8 AS build-ppc64le
-FROM --platform=linux/s390x   quay.io/securesign/gitsign@sha256:482cd580642d2ba2da727dec81c486e580e1e4c895749b59a3e96d30a47e79a8 AS build-s390x
+FROM --platform=linux/amd64   quay.io/securesign/gitsign@sha256:95279d6f4fa651f31a52435e30fa51ca18d64da901207c5139e0ceb21adfb3ca AS build-amd64
+FROM --platform=linux/arm64   quay.io/securesign/gitsign@sha256:55a389c05f7d06e197cbaa542f54a7d750cf134acfd55f2d7ec15658f9ea57a1 AS build-arm64
+FROM --platform=linux/ppc64le quay.io/securesign/gitsign@sha256:0c75997b6447ec952da3ff81ec3d6fb7ce5e3ca169e17e0d7aca2e0edd2405f1 AS build-ppc64le
+FROM --platform=linux/s390x   quay.io/securesign/gitsign@sha256:7c370a9d844b3746f75b1667d984be8d7b9d9553e585d31cae8758cc06c031b0 AS build-s390x
 
 FROM registry.redhat.io/ubi9/go-toolset:9.8-1782377916@sha256:17c888d75753f128f6cbdc5587932c3abd2632ca8e0931aa27b9a60c7a75ac62 AS packager
 USER root


### PR DESCRIPTION
## Summary
Update gitsign cli-stack base images to use platform-specific digests from snapshot tas-tools-v1-4-20260630-165615-000.

## Changes
- Updated platform-specific digests for linux/amd64, linux/arm64, linux/ppc64le, linux/s390x

## Test plan
- [ ] Verify Konflux builds pass
- [ ] Check that generated cli-stack image contains all platform binaries