### PR TITLE
feat: migrate to Go 1.26 native FIPS 140-3

### DIFF
--- a/.tekton/gitsign-cli-stack-pull-request.yaml
+++ b/.tekton/gitsign-cli-stack-pull-request.yaml
@@ -22,6 +22,8 @@ spec:
     value: 1.4.0
   - name: dockerfile
     value: Dockerfile.cli-stack.rh
+  - name: ALLOW_CROSS_PLATFORM_IMAGES
+    value: "true"
   - name: git-url
     value: '{{repo_url}}'
   - name: image-expires-after

--- a/.tekton/gitsign-cli-stack-push.yaml
+++ b/.tekton/gitsign-cli-stack-push.yaml
@@ -22,6 +22,8 @@ spec:
     value: 1.4.0
   - name: dockerfile
     value: Dockerfile.cli-stack.rh
+  - name: ALLOW_CROSS_PLATFORM_IMAGES
+    value: "true"
   - name: git-url
     value: '{{repo_url}}'
   - name: output-image

--- a/.tekton/gitsign-pull-request.yaml
+++ b/.tekton/gitsign-pull-request.yaml
@@ -25,6 +25,8 @@ spec:
     value: 1.4.0
   - name: dockerfile
     value: Dockerfile.gitsign.rh
+  - name: ALLOW_CROSS_PLATFORM_IMAGES
+    value: "true"
   - name: git-url
     value: '{{repo_url}}'
   - name: image-expires-after

--- a/.tekton/gitsign-push.yaml
+++ b/.tekton/gitsign-push.yaml
@@ -25,6 +25,8 @@ spec:
     value: 1.4.0
   - name: dockerfile
     value: Dockerfile.gitsign.rh
+  - name: ALLOW_CROSS_PLATFORM_IMAGES
+    value: "true"
   - name: git-url
     value: '{{repo_url}}'
   - name: output-image

--- a/Build.mak
+++ b/Build.mak
@@ -15,23 +15,23 @@ ifeq ($(DIFF), 1)
 endif
 
 LDFLAGS=-buildid= -X github.com/sigstore/gitsign/pkg/version.gitVersion=$(GIT_VERSION)
-FIPS_MODULE ?= latest
+FIPS_MODULE ?= v1.0.0
 
 .PHONY: gitsign-cli-linux
-gitsign-cli-linux: ## Build native Linux binary (FIPS, CGO)
-	env CGO_ENABLED=1 GOEXPERIMENT=strictfipsruntime go build -mod=readonly -o gitsign_cli_linux -trimpath -ldflags "$(LDFLAGS) -w -s" .
+gitsign-cli-linux: ## Build native Linux binary (native Go FIPS, no OpenSSL)
+	env CGO_ENABLED=0 GOFIPS140=$(FIPS_MODULE) go build -mod=readonly -tags no_openssl -o gitsign_cli_linux -trimpath -ldflags "$(LDFLAGS) -w -s" .
 
 .PHONY:
 cross-platform: gitsign-cli-darwin-arm64 gitsign-cli-darwin-amd64 gitsign-cli-windows ## Build all distributable (cross-platform) binaries
 
 .PHONY:	gitsign-cli-darwin-arm64
 gitsign-cli-darwin-arm64: ## Build for mac M1
-	env CGO_ENABLED=0 GOFIPS140=$(FIPS_MODULE) GOOS=darwin GOARCH=arm64 go build -mod=readonly -o gitsign_cli_darwin_arm64 -trimpath -ldflags "$(LDFLAGS) -w -s" .
+	env CGO_ENABLED=0 GOFIPS140=$(FIPS_MODULE) GOOS=darwin GOARCH=arm64 go build -mod=readonly -tags no_openssl -o gitsign_cli_darwin_arm64 -trimpath -ldflags "$(LDFLAGS) -w -s" .
 
 .PHONY: gitsign-cli-darwin-amd64
 gitsign-cli-darwin-amd64:  ## Build for Darwin (macOS)
-	env CGO_ENABLED=0 GOFIPS140=$(FIPS_MODULE) GOOS=darwin GOARCH=amd64 go build -mod=readonly -o gitsign_cli_darwin_amd64 -trimpath -ldflags "$(LDFLAGS) -w -s" .
+	env CGO_ENABLED=0 GOFIPS140=$(FIPS_MODULE) GOOS=darwin GOARCH=amd64 go build -mod=readonly -tags no_openssl -o gitsign_cli_darwin_amd64 -trimpath -ldflags "$(LDFLAGS) -w -s" .
 
 .PHONY: gitsign-cli-windows
 gitsign-cli-windows: ## Build for Windows
-	env CGO_ENABLED=0 GOFIPS140=$(FIPS_MODULE) GOOS=windows GOARCH=amd64 go build -mod=readonly -o gitsign_cli_windows_amd64.exe -trimpath -ldflags "$(LDFLAGS) -w -s" .
+	env CGO_ENABLED=0 GOFIPS140=$(FIPS_MODULE) GOOS=windows GOARCH=amd64 go build -mod=readonly -tags no_openssl -o gitsign_cli_windows_amd64.exe -trimpath -ldflags "$(LDFLAGS) -w -s" .

--- a/Dockerfile.cli-stack.rh
+++ b/Dockerfile.cli-stack.rh
@@ -17,10 +17,10 @@ RUN git config --global --add safe.directory /opt/app-root/src && \
     go mod download && \
     make -f Build.mak cross-platform
 
-FROM --platform=linux/amd64   quay.io/securesign/gitsign@sha256:5a3369ec549a338f7030aeaaf8d5218c90c26d4f55bd06eef11a1a92206d56c4 AS build-amd64
-FROM --platform=linux/arm64   quay.io/securesign/gitsign@sha256:5a3369ec549a338f7030aeaaf8d5218c90c26d4f55bd06eef11a1a92206d56c4 AS build-arm64
-FROM --platform=linux/ppc64le quay.io/securesign/gitsign@sha256:5a3369ec549a338f7030aeaaf8d5218c90c26d4f55bd06eef11a1a92206d56c4 AS build-ppc64le
-FROM --platform=linux/s390x   quay.io/securesign/gitsign@sha256:5a3369ec549a338f7030aeaaf8d5218c90c26d4f55bd06eef11a1a92206d56c4 AS build-s390x
+FROM --platform=linux/amd64   quay.io/securesign/gitsign@sha256:95d3116a7369482359d3ae22adc0ac830a3ceda36a19bd43945f93e5a121da3a AS build-amd64
+FROM --platform=linux/arm64   quay.io/securesign/gitsign@sha256:7a03e8482e6d6b80c9a710a54b82b0a14de6257cb6f333f164a175fd56267bd5 AS build-arm64
+FROM --platform=linux/ppc64le quay.io/securesign/gitsign@sha256:2608c1b4c0af1fe2cfe25a3b5bd1a43ec0d6497edcbd1d05ea1f15e872b13317 AS build-ppc64le
+FROM --platform=linux/s390x   quay.io/securesign/gitsign@sha256:a3932d3b949b2f58005cf164f2ca990b1be340bcca0e6a8318749710eb24b952 AS build-s390x
 
 FROM registry.redhat.io/ubi9/go-toolset:9.8@sha256:355b23fe885cf565c9313a7e98db742df0aec21456244e808942c56489594251 AS packager
 USER root

--- a/Dockerfile.cli-stack.rh
+++ b/Dockerfile.cli-stack.rh
@@ -2,6 +2,9 @@ FROM registry.redhat.io/ubi9/go-toolset:9.8@sha256:355b23fe885cf565c9313a7e98db7
 ENV APP_ROOT=/opt/app-root \
     GOPATH=/opt/app-root
 
+
+ENV GOFIPS140=v1.0.0
+
 USER root
 WORKDIR $APP_ROOT/src
 ADD go.mod go.sum ./
@@ -10,6 +13,7 @@ ADD ./ ./
 RUN git config --global --add safe.directory /opt/app-root/src && \
     git update-index --assume-unchanged Dockerfile.gitsign.rh && \
     git update-index --assume-unchanged Dockerfile.cli-stack.rh && \
+    go mod edit -godebug=fips140=auto && \
     go mod download && \
     make -f Build.mak cross-platform
 

--- a/Dockerfile.gitsign.rh
+++ b/Dockerfile.gitsign.rh
@@ -1,5 +1,7 @@
 # Build stage
-FROM registry.redhat.io/ubi9/go-toolset:9.7-1774499506@sha256:2830e4bd1c394ed506c00a9abbb4d00445e2e72e8ef4e3cd51e0da0db66dee12 AS build-env
+FROM registry.redhat.io/ubi9/go-toolset:9.8@sha256:355b23fe885cf565c9313a7e98db742df0aec21456244e808942c56489594251 AS build-env
+
+ENV GOFIPS140=v1.0.0
 
 WORKDIR /gitsign
 RUN git config --global --add safe.directory /gitsign
@@ -8,6 +10,7 @@ USER root
 RUN git stash && \
     git stash pop || true && \
     git update-index --assume-unchanged Dockerfile.gitsign.rh && \
+    go mod edit -godebug=fips140=auto && \
     go mod download && \
     make -f Build.mak gitsign-cli-linux && \
     git update-index --no-assume-unchanged Dockerfile.gitsign.rh

--- a/go.mod
+++ b/go.mod
@@ -26,7 +26,6 @@ require (
 	github.com/sigstore/sigstore-go v1.1.4
 	github.com/spf13/cobra v1.10.2
 	github.com/spf13/pflag v1.0.10
-	golang.org/x/crypto v0.49.0
 	golang.org/x/oauth2 v0.36.0
 	golang.org/x/xerrors v0.0.0-20240903120638-7835f813f4da
 	google.golang.org/protobuf v1.36.11
@@ -253,6 +252,7 @@ require (
 	go.uber.org/zap v1.27.1 // indirect
 	go.yaml.in/yaml/v2 v2.4.3 // indirect
 	go.yaml.in/yaml/v3 v3.0.4 // indirect
+	golang.org/x/crypto v0.49.0 // indirect
 	golang.org/x/exp v0.0.0-20260312153236-7ab1446f8b90 // indirect
 	golang.org/x/mod v0.34.0 // indirect
 	golang.org/x/net v0.52.0 // indirect

--- a/go.mod
+++ b/go.mod
@@ -1,6 +1,6 @@
 module github.com/sigstore/gitsign
 
-go 1.25.7
+go 1.26.3
 
 require (
 	github.com/coreos/go-oidc/v3 v3.17.0

--- a/internal/fork/ietf-cms/fips.go
+++ b/internal/fork/ietf-cms/fips.go
@@ -1,0 +1,29 @@
+package cms
+
+import (
+	"crypto"
+	"crypto/fips140"
+	"fmt"
+)
+
+// RHTAS FIPS - DO NOT REMOVE
+// ========================================
+
+func checkFIPSHash(hash crypto.Hash) error {
+	if fips140.Enabled() && !isFIPSApprovedHash(hash) {
+		return fmt.Errorf("hash algorithm %v is not approved in FIPS 140-3 mode", hash)
+	}
+	return nil
+}
+
+func isFIPSApprovedHash(h crypto.Hash) bool {
+	switch h {
+	case crypto.SHA224, crypto.SHA256, crypto.SHA384, crypto.SHA512,
+		crypto.SHA3_224, crypto.SHA3_256, crypto.SHA3_384, crypto.SHA3_512:
+		return true
+	default:
+		return false
+	}
+}
+
+// ========================================

--- a/internal/fork/ietf-cms/timestamp/fips.go
+++ b/internal/fork/ietf-cms/timestamp/fips.go
@@ -1,0 +1,29 @@
+package timestamp
+
+import (
+	"crypto"
+	"crypto/fips140"
+	"fmt"
+)
+
+// RHTAS FIPS - DO NOT REMOVE
+// ========================================
+
+func checkFIPSHash(hash crypto.Hash) error {
+	if fips140.Enabled() && !isFIPSApprovedHash(hash) {
+		return fmt.Errorf("hash algorithm %v is not approved in FIPS 140-3 mode", hash)
+	}
+	return nil
+}
+
+func isFIPSApprovedHash(h crypto.Hash) bool {
+	switch h {
+	case crypto.SHA224, crypto.SHA256, crypto.SHA384, crypto.SHA512,
+		crypto.SHA3_224, crypto.SHA3_256, crypto.SHA3_384, crypto.SHA3_512:
+		return true
+	default:
+		return false
+	}
+}
+
+// ========================================

--- a/internal/fork/ietf-cms/timestamp/timestamp.go
+++ b/internal/fork/ietf-cms/timestamp/timestamp.go
@@ -372,6 +372,14 @@ func NewMessageImprint(hash crypto.Hash, r io.Reader) (MessageImprint, error) {
 	if !hash.Available() {
 		return MessageImprint{}, protocol.ErrUnsupported
 	}
+
+	// RHTAS FIPS - DO NOT REMOVE
+	// ========================================
+	if err := checkFIPSHash(hash); err != nil {
+		return MessageImprint{}, err
+	}
+	// ========================================
+
 	h := hash.New()
 	if _, err := io.Copy(h, r); err != nil {
 		return MessageImprint{}, err

--- a/internal/fork/ietf-cms/verify.go
+++ b/internal/fork/ietf-cms/verify.go
@@ -93,6 +93,14 @@ func (sd *SignedData) verify(econtent []byte, opts x509.VerifyOptions, tsOpts x5
 			if err != nil {
 				return nil, err
 			}
+
+			// RHTAS FIPS - DO NOT REMOVE
+			// ========================================
+			if err := checkFIPSHash(hash); err != nil {
+				return nil, err
+			}
+			// ========================================
+
 			actualMessageDigest := hash.New()
 			if _, err = actualMessageDigest.Write(econtent); err != nil {
 				return nil, err

--- a/internal/gpg/status.go
+++ b/internal/gpg/status.go
@@ -23,15 +23,46 @@ import (
 	"os"
 	"time"
 
-	// TODO: this package is unmaintained except for security fixes.
-	// New applications should consider a more focused, modern alternative to OpenPGP for their specific task.
-	// If you are required to interoperate with OpenPGP systems and need a maintained package, consider a community fork.
-	// See https://golang.org/issue/44226
-	"golang.org/x/crypto/openpgp/packet" //nolint: staticcheck
-	"golang.org/x/crypto/openpgp/s2k"    //nolint: staticcheck
-
 	"github.com/sigstore/gitsign/internal"
 )
+
+// RHTAS FIPS - DO NOT REMOVE
+// ========================================
+// OpenPGP public-key algorithm IDs (RFC 4880 Section 9.1).
+// Inlined to avoid importing golang.org/x/crypto/openpgp/packet.
+const (
+	pubKeyAlgoRSA   = 1
+	pubKeyAlgoECDSA = 19
+)
+
+// hashToHashID maps crypto.Hash values to OpenPGP hash IDs (RFC 4880 Section 9.4).
+// Inlined to avoid importing golang.org/x/crypto/openpgp/s2k.
+func hashToHashID(h crypto.Hash) byte {
+	switch h {
+	case crypto.MD5:
+		return 1
+	case crypto.SHA1:
+		return 2
+	case crypto.RIPEMD160:
+		return 3
+	case crypto.SHA256:
+		return 8
+	case crypto.SHA384:
+		return 9
+	case crypto.SHA512:
+		return 10
+	case crypto.SHA224:
+		return 11
+	case crypto.SHA3_256:
+		return 12
+	case crypto.SHA3_512:
+		return 14
+	default:
+		return 0
+	}
+}
+
+// ========================================
 
 // This file implements gnupg's "status protocol". When the --status-fd argument
 // is passed, gpg will output machine-readable status updates to that fd.
@@ -192,23 +223,26 @@ func (w *StatusWriter) EmitSigCreated(cert *x509.Certificate, isDetached bool) {
 		sigType = "S"
 	}
 
+	// RHTAS FIPS - DO NOT REMOVE
+	// ========================================
 	switch cert.SignatureAlgorithm {
 	case x509.SHA1WithRSA, x509.SHA256WithRSA, x509.SHA384WithRSA, x509.SHA512WithRSA:
-		pkAlgo = byte(packet.PubKeyAlgoRSA)
+		pkAlgo = pubKeyAlgoRSA
 	case x509.ECDSAWithSHA1, x509.ECDSAWithSHA256, x509.ECDSAWithSHA384, x509.ECDSAWithSHA512:
-		pkAlgo = byte(packet.PubKeyAlgoECDSA)
+		pkAlgo = pubKeyAlgoECDSA
 	}
 
 	switch cert.SignatureAlgorithm {
 	case x509.SHA1WithRSA, x509.ECDSAWithSHA1:
-		hashAlgo, _ = s2k.HashToHashId(crypto.SHA1)
+		hashAlgo = hashToHashID(crypto.SHA1)
 	case x509.SHA256WithRSA, x509.ECDSAWithSHA256:
-		hashAlgo, _ = s2k.HashToHashId(crypto.SHA256)
+		hashAlgo = hashToHashID(crypto.SHA256)
 	case x509.SHA384WithRSA, x509.ECDSAWithSHA384:
-		hashAlgo, _ = s2k.HashToHashId(crypto.SHA384)
+		hashAlgo = hashToHashID(crypto.SHA384)
 	case x509.SHA512WithRSA, x509.ECDSAWithSHA512:
-		hashAlgo, _ = s2k.HashToHashId(crypto.SHA512)
+		hashAlgo = hashToHashID(crypto.SHA512)
 	}
+	// ========================================
 
 	// gpgsm seems to always use 0x00
 	sigClass = 0

--- a/internal/utils.go
+++ b/internal/utils.go
@@ -16,6 +16,7 @@
 package internal
 
 import (
+	"crypto/fips140"
 	"crypto/sha1" // #nosec G505
 	"crypto/x509"
 	"encoding/hex"
@@ -33,7 +34,13 @@ func certFingerprint(cert *x509.Certificate) []byte {
 		return nil
 	}
 
-	fpr := sha1.Sum(cert.Raw) // nolint:gosec
+	// RHTAS FIPS - DO NOT REMOVE
+	// ========================================
+	var fpr [sha1.Size]byte
+	fips140.WithoutEnforcement(func() {
+		fpr = sha1.Sum(cert.Raw) // nolint:gosec
+	})
+	// ========================================
 	return fpr[:]
 }
 

--- a/pkg/fulcio/fulcio.go
+++ b/pkg/fulcio/fulcio.go
@@ -15,7 +15,9 @@
 package fulcio
 
 import (
+	"context"
 	"crypto"
+	"crypto/fips140"
 	"crypto/rand"
 	"crypto/sha256"
 	"crypto/x509"
@@ -23,8 +25,10 @@ import (
 	"reflect"
 	"strings"
 
+	"github.com/coreos/go-oidc/v3/oidc"
 	"github.com/sigstore/fulcio/pkg/api"
 	"github.com/sigstore/sigstore/pkg/oauthflow"
+	"golang.org/x/oauth2"
 )
 
 type Client interface {
@@ -66,7 +70,37 @@ func (c *ClientImpl) GetCert(priv crypto.Signer) (*api.CertificateResponse, erro
 		return nil, err
 	}
 
-	tok, err := oauthflow.OIDConnect(c.oidc.Issuer, c.oidc.ClientID, c.oidc.ClientSecret, c.oidc.RedirectURL, c.oidc.TokenGetter)
+	// RHTAS FIPS - DO NOT REMOVE
+	// ========================================
+	// go-jose computes sha1.Sum during JWK parsing (x5t thumbprint) which is
+	// non-cryptographic but would panic under fips140=only.
+	// Same pattern as securesign/fulcio#401.
+	var tok *oauthflow.OIDCIDToken
+	if fips140.Enabled() {
+		if sg, ok := c.oidc.TokenGetter.(*oauthflow.StaticTokenGetter); ok {
+			tok, err = sg.GetIDToken(nil, oauth2.Config{})
+		} else {
+			var provider *oidc.Provider
+			fips140.WithoutEnforcement(func() {
+				provider, err = oidc.NewProvider(context.Background(), c.oidc.Issuer)
+			})
+			if err == nil {
+				config := oauth2.Config{
+					ClientID:     c.oidc.ClientID,
+					ClientSecret: c.oidc.ClientSecret,
+					Endpoint:     provider.Endpoint(),
+					Scopes:       []string{oidc.ScopeOpenID, "email"},
+					RedirectURL:  c.oidc.RedirectURL,
+				}
+				fips140.WithoutEnforcement(func() {
+					tok, err = c.oidc.TokenGetter.GetIDToken(provider, config)
+				})
+			}
+		}
+	} else {
+		tok, err = oauthflow.OIDConnect(c.oidc.Issuer, c.oidc.ClientID, c.oidc.ClientSecret, c.oidc.RedirectURL, c.oidc.TokenGetter)
+	}
+	// ========================================
 	if err != nil {
 		return nil, err
 	}


### PR DESCRIPTION
## Summary
- Replace OpenSSL-backed FIPS (`CGO_ENABLED=1 GOEXPERIMENT=strictfipsruntime`) with Go 1.26 native FIPS (`GOFIPS140=v1.0.0`, `CGO_ENABLED=0`)
- Wrap non-cryptographic SHA-1 cert fingerprint with `fips140.WithoutEnforcement()` in `utils.go`
- Add FIPS hash validation before `hash.New()` in CMS verify and timestamp to prevent panics on non-approved algorithms
- Remove direct `golang.org/x/crypto/openpgp` dependency by inlining RFC 4880 constants
- Add FIPS build config (`GOFIPS140`, `godebug fips140=auto`) to both Dockerfiles
- Add `-tags no_openssl` across all Build.mak targets