### PR TITLE
Update cli-stacks image digests from Wave 1 builds 2026-07-22

### DIFF
--- a/Dockerfile.cli-stack.rh
+++ b/Dockerfile.cli-stack.rh
@@ -13,10 +13,10 @@ RUN git config --global --add safe.directory /opt/app-root/src && \
     go mod download && \
     make -f Build.mak cross-platform
 
-FROM --platform=linux/amd64   quay.io/securesign/gitsign@sha256:76bc11c14f4556f8898056cb3ae3c1cabc271af8ec3e137870fc8a06f60d9091 AS build-amd64
-FROM --platform=linux/arm64   quay.io/securesign/gitsign@sha256:24404bbfcaf540366ae62dde2789c545a2dc39a871f865e0c236c1314bbddb97 AS build-arm64
-FROM --platform=linux/ppc64le quay.io/securesign/gitsign@sha256:6add79e16c6ec117cc8864fbf43dbafcd90f76ac9da712f8ad6d897ed1263463 AS build-ppc64le
-FROM --platform=linux/s390x   quay.io/securesign/gitsign@sha256:e534433fad4132e1c358bbae640fe9b0f60dc0ea757af2435c633ded494a6695 AS build-s390x
+FROM --platform=linux/amd64   quay.io/securesign/gitsign@sha256:2510813b2abbc884cec24a1e7046cb27ed7fef55f70b8f39010daed6ad9f8fe8 AS build-amd64
+FROM --platform=linux/arm64   quay.io/securesign/gitsign@sha256:316af8bfe45085016d6ce014f586eb4b1b9b28e52f472d6ae0f9c5d01e77ca67 AS build-arm64
+FROM --platform=linux/ppc64le quay.io/securesign/gitsign@sha256:096ff4d2c6c90a324e2865d7b1c58a9ce576d5411c7d2c50d7ae43af7e30909d AS build-ppc64le
+FROM --platform=linux/s390x   quay.io/securesign/gitsign@sha256:9b61fbbb000abbf6f01b4b2d35801e6c61f2e4c1480d981248672360124ccafa AS build-s390x
 
 FROM registry.redhat.io/ubi9/go-toolset:9.8-1782980183@sha256:b2bc0c6c92c56dce575ed1b2dec1ec9f8b345a80ef5e74d9bfd530b6b354feeb AS packager
 USER root


### PR DESCRIPTION
Updates gitsign-cli-stack per-architecture digests from Wave 1 snapshot builds for release 1.4.3.

Source snapshots: tas-tools-v1-4-20260722-103132-000, tough-v1-4-20260722-094822-000, create-tree-v1-4-20260722-102302-000