### PR TITLE
Update release-version to 1.5.0

### DIFF
--- a/.tekton/gitsign-cli-stack-pull-request.yaml
+++ b/.tekton/gitsign-cli-stack-pull-request.yaml
@@ -19,7 +19,7 @@ metadata:
 spec:
   params:
   - name: release-version
-    value: 1.4.0
+    value: 1.5.0
   - name: dockerfile
     value: Dockerfile.cli-stack.rh
   - name: ALLOW_CROSS_PLATFORM_IMAGES

--- a/.tekton/gitsign-cli-stack-push.yaml
+++ b/.tekton/gitsign-cli-stack-push.yaml
@@ -19,7 +19,7 @@ metadata:
 spec:
   params:
   - name: release-version
-    value: 1.4.0
+    value: 1.5.0
   - name: dockerfile
     value: Dockerfile.cli-stack.rh
   - name: ALLOW_CROSS_PLATFORM_IMAGES

--- a/.tekton/gitsign-pull-request.yaml
+++ b/.tekton/gitsign-pull-request.yaml
@@ -22,7 +22,7 @@ metadata:
 spec:
   params:
   - name: release-version
-    value: 1.4.0
+    value: 1.5.0
   - name: dockerfile
     value: Dockerfile.gitsign.rh
   - name: ALLOW_CROSS_PLATFORM_IMAGES

--- a/.tekton/gitsign-push.yaml
+++ b/.tekton/gitsign-push.yaml
@@ -22,7 +22,7 @@ metadata:
 spec:
   params:
   - name: release-version
-    value: 1.4.0
+    value: 1.5.0
   - name: dockerfile
     value: Dockerfile.gitsign.rh
   - name: ALLOW_CROSS_PLATFORM_IMAGES


### PR DESCRIPTION
## Summary
- Update `release-version` parameter from `1.4.0` to `1.5.0` in all `.tekton` pipeline definitions

## Test plan
- [ ] Verify Tekton pipeline definitions are valid YAML
- [ ] Confirm `release-version` is set to `1.5.0` in all pipeline files

🤖 Generated with [Claude Code](https://claude.com/claude-code)