### PR TITLE
Update cli-stacks image digests from Wave 1 builds 2026-07-29

### DIFF
--- a/Dockerfile.cli-stack.rh
+++ b/Dockerfile.cli-stack.rh
@@ -13,10 +13,10 @@ RUN git config --global --add safe.directory /opt/app-root/src && \
     go mod download && \
     make -f Build.mak cross-platform
 
-FROM --platform=linux/amd64   quay.io/securesign/gitsign@sha256:2510813b2abbc884cec24a1e7046cb27ed7fef55f70b8f39010daed6ad9f8fe8 AS build-amd64
-FROM --platform=linux/arm64   quay.io/securesign/gitsign@sha256:316af8bfe45085016d6ce014f586eb4b1b9b28e52f472d6ae0f9c5d01e77ca67 AS build-arm64
-FROM --platform=linux/ppc64le quay.io/securesign/gitsign@sha256:096ff4d2c6c90a324e2865d7b1c58a9ce576d5411c7d2c50d7ae43af7e30909d AS build-ppc64le
-FROM --platform=linux/s390x   quay.io/securesign/gitsign@sha256:9b61fbbb000abbf6f01b4b2d35801e6c61f2e4c1480d981248672360124ccafa AS build-s390x
+FROM --platform=linux/amd64   quay.io/securesign/gitsign@sha256:5b8d476718345f00ec8687aed72ef4af4cdb0f29ff409c8cf810d813a88e49c6 AS build-amd64
+FROM --platform=linux/arm64   quay.io/securesign/gitsign@sha256:401d4eca578bf68d56d729c57454c945c253b73ef0f2bf5f36850ef132e89c36 AS build-arm64
+FROM --platform=linux/ppc64le quay.io/securesign/gitsign@sha256:c025dd87f65ecd760353c95865428b6247d33828da3ba3382078054e0450f3e9 AS build-ppc64le
+FROM --platform=linux/s390x   quay.io/securesign/gitsign@sha256:cf35331337b5926a93faa4ffe74c7a984f5390d881e7974c821b2b9f10426b3c AS build-s390x
 
 FROM registry.redhat.io/ubi9/go-toolset:9.8-1782980183@sha256:b2bc0c6c92c56dce575ed1b2dec1ec9f8b345a80ef5e74d9bfd530b6b354feeb AS packager
 USER root


### PR DESCRIPTION
Updates gitsign per-arch digests in Dockerfile.cli-stack.rh from today's Wave 1 builds.

Source snapshot: tas-tools-v1-4-20260729-115633-000