### PR TITLE
build: enable hermetic builds for gitsign cli-stack

### DIFF
--- a/.tekton/gitsign-cli-stack-pull-request.yaml
+++ b/.tekton/gitsign-cli-stack-pull-request.yaml
@@ -34,8 +34,10 @@ spec:
     value: .
   - name: revision
     value: '{{revision}}'
+  - name: prefetch-input
+    value: '{"type": "gomod", "path": "."}'
   - name: hermetic
-    value: "false"
+    value: "true"
   - name: build-source-image
     value: "true"
   pipelineRef:

--- a/.tekton/gitsign-cli-stack-push.yaml
+++ b/.tekton/gitsign-cli-stack-push.yaml
@@ -35,7 +35,7 @@ spec:
   - name: prefetch-input
     value: '{"type": "gomod", "path": "."}'
   - name: hermetic
-    value: "false"
+    value: "true"
   - name: build-source-image
     value: "true"
   pipelineRef:


### PR DESCRIPTION
## Summary
- Enable hermetic builds for the `gitsign-cli-stack` component (both push and pull-request pipelines)
- Add `prefetch-input` with gomod cachi2 prefetch to the PR pipeline (push already had it)

## Test plan
- [ ] Verify the cli-stack PR build passes with hermetic enabled